### PR TITLE
Fix unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.0.12 - 12 May 2024
+
+* Fixes wrapping of words longer than the width of the multi-line input
+* Fixes tests, such as they are
+
 # v0.0.11 - 28 April 2024
 
 * Added `{dir}_arrow` to fix cursor keys not working in recent 5.2X versions

--- a/app/book_sample.rb
+++ b/app/book_sample.rb
@@ -82,7 +82,7 @@ def tick(args)
   args.outputs.primitives << { y: 658, text: "#{args.state.text.value.length}/40", **DEBUG_LABEL, x: 1220 }
   args.outputs.primitives << { y: 140, text: "Simple Value: #{nval}" }.label!(DEBUG_LABEL)
   args.outputs.primitives << { y: 110, text: "Wrapping Value (#{wval.length}): #{wval.gsub("\n", '\n')}" }.label!(DEBUG_LABEL)
-  args.outputs.primitives << { y: 90, text: "Current word: #{args.state.multiline.current_word}", **DEBUG_LABEL }
+  # args.outputs.primitives << { y: 90, text: "Current word: #{args.state.multiline.current_word}", **DEBUG_LABEL }
   args.outputs.primitives << { y: 70, text: "Current line: #{args.state.multiline.current_line.inspect}" }.label!(DEBUG_LABEL)
   args.outputs.primitives << { y: 40, text: "Clipboard: #{$clipboard}" }.label!(DEBUG_LABEL)
   args.outputs.primitives << { y: 20, text: "Content rect: #{args.state.multiline.content_rect}, Scroll rect: #{args.state.multiline.scroll_rect}" }.label!(DEBUG_LABEL)

--- a/lib/line_collection.rb
+++ b/lib/line_collection.rb
@@ -216,8 +216,8 @@ module Input
       lines = LineCollection.new(@font, @size_enum)
       line = ''
       i = -1
-      l = words.length
-      while (i += 1) < l
+      le = words.length
+      while (i += 1) < le
         word = words[i]
         if word == "\n"
           unless line == ''
@@ -228,25 +228,51 @@ module Input
         else
           w, = $gtk.calcstringbox((line + word).rstrip, @size_enum, @font)
           if w > width
-            if line != ''
+            unless line == ''
               lines << Line.new(lines.length + first_line_number, first_line_start, line, true, @font, @size_enum)
               first_line_start = lines.last.end
             end
 
             # break up long words
             w, = $gtk.calcstringbox(word.rstrip, @size_enum, @font)
+            # TODO: make this a binary search
             while w > width
-              n = word.length
-              while w > width
-                n -= 1
-                w, = $gtk.calcstringbox(word[0, n].rstrip, @size_enum, @font)
-                if w <= width
-                  lines << Line.new(lines.length + first_line_number, first_line_start, word[0, n], true, @font, @size_enum)
+              r = word.length - 1
+              l = 0
+              m = r.idiv(2)
+              w, = $gtk.calcstringbox(word[0, m].rstrip, @size_enum, @font)
+              loop do
+                if w == width
+                  # Whoa, add this
+                  lines << Line.new(lines.length + first_line_number, first_line_start, word[0, m], true, @font, @size_enum)
                   first_line_start = lines.last.end
-                  word = word[n, word.length]
-                end
-              end
+                  word = word[m, word.length]
+                  break
+                elsif w < width
+                  if r - l <= 1
+                    lines << Line.new(lines.length + first_line_number, first_line_start, word[0, r], true, @font, @size_enum)
+                    first_line_start = lines.last.end
+                    word = word[r, word.length]
+                    break
+                  end
 
+                  # go right
+                  l = m + 1
+                  m = (l + r).idiv(2)
+                elsif w > width
+                  if r - l <= 1
+                    lines << Line.new(lines.length + first_line_number, first_line_start, word[0, l], true, @font, @size_enum)
+                    first_line_start = lines.last.end
+                    word = word[l, word.length]
+                    break
+                  end
+
+                  # go left
+                  r = m - 1
+                  m = (l + r).idiv(2)
+                end
+                w, = $gtk.calcstringbox(word[0, m].rstrip, @size_enum, @font)
+              end
               w, = $gtk.calcstringbox(word.rstrip, @size_enum, @font)
             end
             line = word

--- a/lib/line_collection.rb
+++ b/lib/line_collection.rb
@@ -228,8 +228,27 @@ module Input
         else
           w, = $gtk.calcstringbox((line + word).rstrip, @size_enum, @font)
           if w > width
-            lines << Line.new(lines.length + first_line_number, first_line_start, line, true, @font, @size_enum)
-            first_line_start = lines.last.end
+            if line != ''
+              lines << Line.new(lines.length + first_line_number, first_line_start, line, true, @font, @size_enum)
+              first_line_start = lines.last.end
+            end
+
+            # break up long words
+            w, = $gtk.calcstringbox(word.rstrip, @size_enum, @font)
+            while w > width
+              n = word.length
+              while w > width
+                n -= 1
+                w, = $gtk.calcstringbox(word[0, n].rstrip, @size_enum, @font)
+                if w <= width
+                  lines << Line.new(lines.length + first_line_number, first_line_start, word[0, n], true, @font, @size_enum)
+                  first_line_start = lines.last.end
+                  word = word[n, word.length]
+                end
+              end
+
+              w, = $gtk.calcstringbox(word.rstrip, @size_enum, @font)
+            end
             line = word
           elsif word.start_with?("\n")
             unless line == ''

--- a/test
+++ b/test
@@ -1,3 +1,3 @@
 cd ..
-./dragonruby dr-input --test tests/tests.rb --no-tick
+SDL_VIDEODRIVER=dummy SDL_AUDIODRIVER=dummy ./dragonruby dr-input --test tests/tests.rb --no-tick
 cd -

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -40,9 +40,12 @@ end
 #   assert.equal! Input::Multiline.new.find_word_breaks('a'), ['a']
 # end
 
-# def test_find_word_breaks_2_words(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks('hello, world'), ['hello, ', 'world']
-# end
+def test_multiline_word_breaks_two_words(_args, assert)
+  multiline = build_ten_letter_wide_multiline
+  multiline.insert 'Hello, world'
+
+  assert.equal! multiline.lines.map(&:text), ['Hello, ', 'world']
+end
 
 # def test_find_word_breaks_leading_and_trailing_white_space(_args, assert)
 #   assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello \t "), [" \t  hello \t "]
@@ -91,3 +94,8 @@ end
 # def test_perform_word_wrap_trailing_new_line_after_wrap(args, assert)
 #   assert.equal! Input::Multiline.new.perform_word_wrap(['', '']), ["1\n", '']
 # end
+
+def build_ten_letter_wide_multiline(value = nil)
+  ten_letters_width, _ = $gtk.calcstringbox('1234567890', 0)
+  Input::Multiline.new(w: ten_letters_width, value: value || '')
+end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -29,65 +29,65 @@ def test_calcstringbox_tab_has_no_witdh(_args, assert)
 end
 
 def test_find_word_breaks_empty_value(_args, assert)
-  assert.equal! omg_test_the_thing(''), ['']
+  assert.equal! word_wrap_result(''), ['']
 end
 
 def test_find_word_breaks_single_space(_args, assert)
-  assert.equal! omg_test_the_thing(' '), [' ']
+  assert.equal! word_wrap_result(' '), [' ']
 end
 
 def test_find_word_breaks_single_char(_args, assert)
-  assert.equal! omg_test_the_thing('a'), ['a']
+  assert.equal! word_wrap_result('a'), ['a']
 end
 
 def test_multiline_word_breaks_two_words(_args, assert)
-  assert.equal! omg_test_the_thing('Hello, world'), ['Hello, ', 'world']
+  assert.equal! word_wrap_result('Hello, world'), ['Hello, ', 'world']
 end
 
 def test_find_word_breaks_leading_and_trailing_white_space(_args, assert)
-  assert.equal! omg_test_the_thing(" \t  hello \t "), [" \t  hello \t "]
+  assert.equal! word_wrap_result(" \t  hello \t "), [" \t  hello \t "]
 end
 
 def test_find_word_breaks_leading_and_trailing_white_space_multiple_words(_args, assert)
-  assert.equal! omg_test_the_thing(" \t  hello, \t  world \t"), [" \t  hello, \t  ", "world \t"]
+  assert.equal! word_wrap_result(" \t  hello, \t  world \t"), [" \t  hello, \t  ", "world \t"]
 end
 
 def test_multiline_word_breaks_trailing_new_line(_args, assert)
-  assert.equal! omg_test_the_thing("hello, \n"), ['hello, ', "\n"]
+  assert.equal! word_wrap_result("hello, \n"), ['hello, ', "\n"]
 end
 
 def test_multiline_word_breaks_new_line(_args, assert)
-  assert.equal! omg_test_the_thing("hello, \n  world"), ['hello, ', "\n  world"]
+  assert.equal! word_wrap_result("hello, \n  world"), ['hello, ', "\n  world"]
 end
 
 def test_multiline_word_breaks_double_new_line(_args, assert)
-  assert.equal! omg_test_the_thing("hello, \n\n  world"), ['hello, ', "\n", "\n  world"]
+  assert.equal! word_wrap_result("hello, \n\n  world"), ['hello, ', "\n", "\n  world"]
 end
 
 def test_multiline_word_breaks_multiple_new_lines(_args, assert)
-  assert.equal! omg_test_the_thing("hello, \n\n\n  world"), ['hello, ', "\n", "\n", "\n  world"]
+  assert.equal! word_wrap_result("hello, \n\n\n  world"), ['hello, ', "\n", "\n", "\n  world"]
 end
 
 def test_perform_word_wrap_multiple_new_lines(_args, assert)
-  assert.equal! omg_test_the_thing("1\n\n\n2"), ['1', "\n", "\n", "\n2"]
+  assert.equal! word_wrap_result("1\n\n\n2"), ['1', "\n", "\n", "\n2"]
 end
 
 def test_perform_word_wrap_trailing_new_line(_args, assert)
-  assert.equal! omg_test_the_thing("1\n"), ['1', "\n"]
+  assert.equal! word_wrap_result("1\n"), ['1', "\n"]
 end
 
 def test_find_word_breaks_trailing_new_line_after_wrap(_args, assert)
-  assert.equal! omg_test_the_thing("1234567890 1234567890 1234567890\n"), ['1234567890 ', '1234567890 ', '1234567890', "\n"]
+  assert.equal! word_wrap_result("1234567890 1234567890 1234567890\n"), ['1234567890 ', '1234567890 ', '1234567890', "\n"]
 end
 
 def test_multiline_word_breaks_a_very_long_word(_args, assert)
   # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
-  assert.equal! omg_test_the_thing('Supercalifragilisticexpialidocious'), ['Supercalif', 'ragilistic', 'expialidoc', 'ious']
+  assert.equal! word_wrap_result('Supercalifragilisticexpialidocious'), ['Supercalif', 'ragilistic', 'expialidoc', 'ious']
 end
 
 def test_multiline_word_breaks_breaks_very_long_word_after_something_that_isnt(_args, assert)
   # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
-  assert.equal! omg_test_the_thing('Super califragilisticexpialidocious'), ['Super cali', 'fragilisti', 'cexpialido', 'cious']
+  assert.equal! word_wrap_result('Super califragilisticexpialidocious'), ['Super ', 'califragil', 'isticexpia', 'lidocious']
 end
 
 def build_multiline_input(width_in_letters)
@@ -96,7 +96,7 @@ def build_multiline_input(width_in_letters)
   Input::Multiline.new(w: width)
 end
 
-def omg_test_the_thing(string, width_in_letters = 10)
+def word_wrap_result(string, width_in_letters = 10)
   multiline = build_multiline_input(10)
   multiline.insert string
   multiline.lines.map(&:text)

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -28,99 +28,71 @@ def test_calcstringbox_tab_has_no_witdh(_args, assert)
   assert.equal! h, 22.0 # Yep, it has a height
 end
 
-# REVIEW: Are these still needed?
-# def test_find_word_breaks_empty_value(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks(''), ['']
-# end
+def test_find_word_breaks_empty_value(_args, assert)
+  assert.equal! omg_test_the_thing(''), ['']
+end
 
-# def test_find_word_breaks_single_space(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks(' '), [' ']
-# end
+def test_find_word_breaks_single_space(_args, assert)
+  assert.equal! omg_test_the_thing(' '), [' ']
+end
 
-# def test_find_word_breaks_single_char(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks('a'), ['a']
-# end
+def test_find_word_breaks_single_char(_args, assert)
+  assert.equal! omg_test_the_thing('a'), ['a']
+end
 
 def test_multiline_word_breaks_two_words(_args, assert)
-  multiline = build_multiline_input(10)
-  multiline.insert 'Hello, world'
-
-  assert.equal! multiline.lines.map(&:text), ['Hello, ', 'world']
+  assert.equal! omg_test_the_thing('Hello, world'), ['Hello, ', 'world']
 end
 
-# REVIEW: This one doesn't work anymore when used on the actual Multiline instance
-# def test_find_word_breaks_leading_and_trailing_white_space(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello \t "), [" \t  hello \t "]
-# end
-
-# REVIEW: Is this still needed?
-# def test_find_word_breaks_leading_and_trailing_white_space_multiple_words(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello, \t  world \t"), [" \t  hello, \t  ", "world \t"]
-# end
-
-def test_multiline_word_breaks_new_line(_args, assert)
-  multiline = build_multiline_input(10)
-  multiline.insert "hello, \n  world"
-
-  assert.equal! multiline.lines.map(&:text), ['hello, ', "\n  world"]
+def test_find_word_breaks_leading_and_trailing_white_space(_args, assert)
+  assert.equal! omg_test_the_thing(" \t  hello \t "), [" \t  hello \t "]
 end
 
-def test_multiline_word_breaks_double_new_line(_args, assert)
-  multiline = build_multiline_input(10)
-  multiline.insert "hello, \n\n  world"
-
-  assert.equal! multiline.lines.map(&:text), ['hello, ', "\n", "\n  world"]
-end
-
-def test_multiline_word_breaks_multiple_new_lines(_args, assert)
-  multiline = build_multiline_input(10)
-  multiline.insert "hello, \n\n\n  world"
-
-  assert.equal! multiline.lines.map(&:text), ['hello, ', "\n", "\n", "\n  world"]
+def test_find_word_breaks_leading_and_trailing_white_space_multiple_words(_args, assert)
+  assert.equal! omg_test_the_thing(" \t  hello, \t  world \t"), [" \t  hello, \t  ", "world \t"]
 end
 
 def test_multiline_word_breaks_trailing_new_line(_args, assert)
-  multiline = build_multiline_input(10)
-  multiline.insert "hello, \n"
-
-  assert.equal! multiline.lines.map(&:text), ['hello, ', "\n"]
+  assert.equal! omg_test_the_thing("hello, \n"), ['hello, ', "\n"]
 end
 
-# REVIEW: Are these still needed?
-# def test_perform_word_wrap_multiple_new_lines(_args, assert)
-#   assert.equal! Input::Multiline.new.perform_word_wrap(['1', "\n", "\n", "\n2"]).map(&:text), ['1', "\n", "\n", "\n2"]
-# end
+def test_multiline_word_breaks_new_line(_args, assert)
+  assert.equal! omg_test_the_thing("hello, \n  world"), ['hello, ', "\n  world"]
+end
 
-# def test_perform_word_wrap_trailing_new_line(_args, assert)
-#   assert.equal! Input::Multiline.new.perform_word_wrap(['1', "\n"]).map(&:text), ['1', "\n"]
-# end
+def test_multiline_word_breaks_double_new_line(_args, assert)
+  assert.equal! omg_test_the_thing("hello, \n\n  world"), ['hello, ', "\n", "\n  world"]
+end
 
-# def test_find_word_breaks_trailing_new_line_after_wrap(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks("1234567890 1234567890 1234567890\n"), ['1234567890 ', '1234567890 ', '1234567890', "\n"]
-# end
+def test_multiline_word_breaks_multiple_new_lines(_args, assert)
+  assert.equal! omg_test_the_thing("hello, \n\n\n  world"), ['hello, ', "\n", "\n", "\n  world"]
+end
 
-# def test_perform_word_wrap_trailing_new_line_after_wrap(_args, assert)
-#   assert.equal! Input::Multiline.new.perform_word_wrap(['1234567890 ', '1234567890 ', '1234567890', "\n"]).map(&:text), ['1234567890 1234567890 ', '1234567890', "\n"]
-# end
+def test_perform_word_wrap_multiple_new_lines(_args, assert)
+  assert.equal! omg_test_the_thing("1\n\n\n2"), ['1', "\n", "\n", "\n2"]
+end
 
-# def test_find_word_breaks_trailing_new_line_after_wrap_with_space(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks("1234567890 1234567890 \n"), ['1234567890 ', '1234567890 ', "\n"]
-# end
+def test_perform_word_wrap_trailing_new_line(_args, assert)
+  assert.equal! omg_test_the_thing("1\n"), ['1', "\n"]
+end
 
-# def test_perform_word_wrap_trailing_new_line_after_wrap(args, assert)
-#   assert.equal! Input::Multiline.new.perform_word_wrap(['', '']), ["1\n", '']
-# end
+def test_find_word_breaks_trailing_new_line_after_wrap(_args, assert)
+  assert.equal! omg_test_the_thing("1234567890 1234567890 1234567890\n"), ['1234567890 ', '1234567890 ', '1234567890', "\n"]
+end
 
 def test_multiline_word_breaks_doesnt_break_very_long_word(_args, assert)
-  multiline = build_multiline_input(10)
-  multiline.insert 'Supercalifragilisticexpialidocious'
-
   # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
-  assert.equal! multiline.lines.map(&:text), ['Supercalifragilisticexpialidocious']
+  assert.equal! omg_test_the_thing('Supercalifragilisticexpialidocious'), ['Supercalifragilisticexpialidocious']
 end
 
 def build_multiline_input(width_in_letters)
   # This works because the default DR font is monospaced
   width, _ = $gtk.calcstringbox('1' * width_in_letters, 0)
   Input::Multiline.new(w: width)
+end
+
+def omg_test_the_thing(string, width_in_letters = 10)
+  multiline = build_multiline_input(10)
+  multiline.insert string
+  multiline.lines.map(&:text)
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -28,6 +28,7 @@ def test_calcstringbox_tab_has_no_witdh(_args, assert)
   assert.equal! h, 22.0 # Yep, it has a height
 end
 
+# REVIEW: Are these still needed?
 # def test_find_word_breaks_empty_value(_args, assert)
 #   assert.equal! Input::Multiline.new.find_word_breaks(''), ['']
 # end
@@ -47,10 +48,12 @@ def test_multiline_word_breaks_two_words(_args, assert)
   assert.equal! multiline.lines.map(&:text), ['Hello, ', 'world']
 end
 
+# REVIEW: This one doesn't work anymore when used on the actual Multiline instance
 # def test_find_word_breaks_leading_and_trailing_white_space(_args, assert)
 #   assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello \t "), [" \t  hello \t "]
 # end
 
+# REVIEW: Is this still needed?
 # def test_find_word_breaks_leading_and_trailing_white_space_multiple_words(_args, assert)
 #   assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello, \t  world \t"), [" \t  hello, \t  ", "world \t"]
 # end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -81,12 +81,10 @@ def test_find_word_breaks_trailing_new_line_after_wrap(_args, assert)
 end
 
 def test_multiline_word_breaks_a_very_long_word(_args, assert)
-  # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
   assert.equal! word_wrap_result('Supercalifragilisticexpialidocious'), ['Supercalif', 'ragilistic', 'expialidoc', 'ious']
 end
 
 def test_multiline_word_breaks_breaks_very_long_word_after_something_that_isnt(_args, assert)
-  # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
   assert.equal! word_wrap_result('Super califragilisticexpialidocious'), ['Super ', 'califragil', 'isticexpia', 'lidocious']
 end
 

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -58,9 +58,12 @@ end
 #   assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello, \t  world \t"), [" \t  hello, \t  ", "world \t"]
 # end
 
-# def test_find_word_breaks_new_line(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks("hello, \n  world"), ['hello, ', "\n  world"]
-# end
+def test_multiline_word_breaks_new_line(_args, assert)
+  multiline = build_ten_letter_wide_multiline
+  multiline.insert "hello, \n  world"
+
+  assert.equal! multiline.lines.map(&:text), ['hello, ', "\n  world"]
+end
 
 # def test_find_word_breaks_double_new_line(_args, assert)
 #   assert.equal! Input::Multiline.new.find_word_breaks("hello, \n\n  world"), ['hello, ', "\n", "\n  world"]

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -80,9 +80,14 @@ def test_find_word_breaks_trailing_new_line_after_wrap(_args, assert)
   assert.equal! omg_test_the_thing("1234567890 1234567890 1234567890\n"), ['1234567890 ', '1234567890 ', '1234567890', "\n"]
 end
 
-def test_multiline_word_breaks_doesnt_break_very_long_word(_args, assert)
+def test_multiline_word_breaks_a_very_long_word(_args, assert)
   # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
-  assert.equal! omg_test_the_thing('Supercalifragilisticexpialidocious'), ['Supercalifragilisticexpialidocious']
+  assert.equal! omg_test_the_thing('Supercalifragilisticexpialidocious'), ['Supercalif', 'ragilistic', 'expialidoc', 'ious']
+end
+
+def test_multiline_word_breaks_breaks_very_long_word_after_something_that_isnt(_args, assert)
+  # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
+  assert.equal! omg_test_the_thing('Super califragilisticexpialidocious'), ['Super cali', 'fragilisti', 'cexpialido', 'cious']
 end
 
 def build_multiline_input(width_in_letters)

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -65,17 +65,26 @@ def test_multiline_word_breaks_new_line(_args, assert)
   assert.equal! multiline.lines.map(&:text), ['hello, ', "\n  world"]
 end
 
-# def test_find_word_breaks_double_new_line(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks("hello, \n\n  world"), ['hello, ', "\n", "\n  world"]
-# end
+def test_multiline_word_breaks_double_new_line(_args, assert)
+  multiline = build_ten_letter_wide_multiline
+  multiline.insert "hello, \n\n  world"
 
-# def test_find_word_breaks_multiple_new_lines(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks("1\n\n\n2"), ['1', "\n", "\n", "\n2"]
-# end
+  assert.equal! multiline.lines.map(&:text), ['hello, ', "\n", "\n  world"]
+end
 
-# def test_find_word_breaks_trailing_new_line(_args, assert)
-#   assert.equal! Input::Multiline.new.find_word_breaks("1\n"), ['1', "\n"]
-# end
+def test_multiline_word_breaks_multiple_new_lines(_args, assert)
+  multiline = build_ten_letter_wide_multiline
+  multiline.insert "hello, \n\n\n  world"
+
+  assert.equal! multiline.lines.map(&:text), ['hello, ', "\n", "\n", "\n  world"]
+end
+
+def test_multiline_word_breaks_trailing_new_line(_args, assert)
+  multiline = build_ten_letter_wide_multiline
+  multiline.insert "hello, \n"
+
+  assert.equal! multiline.lines.map(&:text), ['hello, ', "\n"]
+end
 
 # def test_perform_word_wrap_multiple_new_lines(_args, assert)
 #   assert.equal! Input::Multiline.new.perform_word_wrap(['1', "\n", "\n", "\n2"]).map(&:text), ['1', "\n", "\n", "\n2"]

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -111,6 +111,14 @@ end
 #   assert.equal! Input::Multiline.new.perform_word_wrap(['', '']), ["1\n", '']
 # end
 
+def test_multiline_word_breaks_doesnt_break_very_long_word(_args, assert)
+  multiline = build_ten_letter_wide_multiline
+  multiline.insert 'Supercalifragilisticexpialidocious'
+
+  # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
+  assert.equal! multiline.lines.map(&:text), ['Supercalifragilisticexpialidocious']
+end
+
 def build_ten_letter_wide_multiline(value = nil)
   ten_letters_width, _ = $gtk.calcstringbox('1234567890', 0)
   Input::Multiline.new(w: ten_letters_width, value: value || '')

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -42,7 +42,7 @@ end
 # end
 
 def test_multiline_word_breaks_two_words(_args, assert)
-  multiline = build_ten_letter_wide_multiline
+  multiline = build_multiline_input(10)
   multiline.insert 'Hello, world'
 
   assert.equal! multiline.lines.map(&:text), ['Hello, ', 'world']
@@ -59,28 +59,28 @@ end
 # end
 
 def test_multiline_word_breaks_new_line(_args, assert)
-  multiline = build_ten_letter_wide_multiline
+  multiline = build_multiline_input(10)
   multiline.insert "hello, \n  world"
 
   assert.equal! multiline.lines.map(&:text), ['hello, ', "\n  world"]
 end
 
 def test_multiline_word_breaks_double_new_line(_args, assert)
-  multiline = build_ten_letter_wide_multiline
+  multiline = build_multiline_input(10)
   multiline.insert "hello, \n\n  world"
 
   assert.equal! multiline.lines.map(&:text), ['hello, ', "\n", "\n  world"]
 end
 
 def test_multiline_word_breaks_multiple_new_lines(_args, assert)
-  multiline = build_ten_letter_wide_multiline
+  multiline = build_multiline_input(10)
   multiline.insert "hello, \n\n\n  world"
 
   assert.equal! multiline.lines.map(&:text), ['hello, ', "\n", "\n", "\n  world"]
 end
 
 def test_multiline_word_breaks_trailing_new_line(_args, assert)
-  multiline = build_ten_letter_wide_multiline
+  multiline = build_multiline_input(10)
   multiline.insert "hello, \n"
 
   assert.equal! multiline.lines.map(&:text), ['hello, ', "\n"]
@@ -112,15 +112,15 @@ end
 # end
 
 def test_multiline_word_breaks_doesnt_break_very_long_word(_args, assert)
-  multiline = build_ten_letter_wide_multiline
+  multiline = build_multiline_input(10)
   multiline.insert 'Supercalifragilisticexpialidocious'
 
   # REVIEW: This breaks and actually returns ["", "Supercalifragilisticexpialidocious"] - is this behavior as intended?
   assert.equal! multiline.lines.map(&:text), ['Supercalifragilisticexpialidocious']
 end
 
-def build_ten_letter_wide_multiline(value = nil)
+def build_multiline_input(width_in_letters)
   # This works because the default DR font is monospaced
-  ten_letters_width, _ = $gtk.calcstringbox('1234567890', 0)
-  Input::Multiline.new(w: ten_letters_width, value: value || '')
+  width, _ = $gtk.calcstringbox('1' * width_in_letters, 0)
+  Input::Multiline.new(w: width)
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -120,6 +120,7 @@ def test_multiline_word_breaks_doesnt_break_very_long_word(_args, assert)
 end
 
 def build_ten_letter_wide_multiline(value = nil)
+  # This works because the default DR font is monospaced
   ten_letters_width, _ = $gtk.calcstringbox('1234567890', 0)
   Input::Multiline.new(w: ten_letters_width, value: value || '')
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -28,65 +28,65 @@ def test_calcstringbox_tab_has_no_witdh(_args, assert)
   assert.equal! h, 22.0 # Yep, it has a height
 end
 
-def test_find_word_breaks_empty_value(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks(''), ['']
-end
+# def test_find_word_breaks_empty_value(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks(''), ['']
+# end
 
-def test_find_word_breaks_single_space(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks(' '), [' ']
-end
+# def test_find_word_breaks_single_space(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks(' '), [' ']
+# end
 
-def test_find_word_breaks_single_char(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks('a'), ['a']
-end
+# def test_find_word_breaks_single_char(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks('a'), ['a']
+# end
 
-def test_find_word_breaks_2_words(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks('hello, world'), ['hello, ', 'world']
-end
+# def test_find_word_breaks_2_words(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks('hello, world'), ['hello, ', 'world']
+# end
 
-def test_find_word_breaks_leading_and_trailing_white_space(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello \t "), [" \t  hello \t "]
-end
+# def test_find_word_breaks_leading_and_trailing_white_space(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello \t "), [" \t  hello \t "]
+# end
 
-def test_find_word_breaks_leading_and_trailing_white_space_multiple_words(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello, \t  world \t"), [" \t  hello, \t  ", "world \t"]
-end
+# def test_find_word_breaks_leading_and_trailing_white_space_multiple_words(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks(" \t  hello, \t  world \t"), [" \t  hello, \t  ", "world \t"]
+# end
 
-def test_find_word_breaks_new_line(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks("hello, \n  world"), ['hello, ', "\n  world"]
-end
+# def test_find_word_breaks_new_line(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks("hello, \n  world"), ['hello, ', "\n  world"]
+# end
 
-def test_find_word_breaks_double_new_line(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks("hello, \n\n  world"), ['hello, ', "\n", "\n  world"]
-end
+# def test_find_word_breaks_double_new_line(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks("hello, \n\n  world"), ['hello, ', "\n", "\n  world"]
+# end
 
-def test_find_word_breaks_multiple_new_lines(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks("1\n\n\n2"), ['1', "\n", "\n", "\n2"]
-end
+# def test_find_word_breaks_multiple_new_lines(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks("1\n\n\n2"), ['1', "\n", "\n", "\n2"]
+# end
 
-def test_find_word_breaks_trailing_new_line(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks("1\n"), ['1', "\n"]
-end
+# def test_find_word_breaks_trailing_new_line(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks("1\n"), ['1', "\n"]
+# end
 
-def test_perform_word_wrap_multiple_new_lines(_args, assert)
-  assert.equal! Input::Multiline.new.perform_word_wrap(['1', "\n", "\n", "\n2"]).map(&:text), ['1', "\n", "\n", "\n2"]
-end
+# def test_perform_word_wrap_multiple_new_lines(_args, assert)
+#   assert.equal! Input::Multiline.new.perform_word_wrap(['1', "\n", "\n", "\n2"]).map(&:text), ['1', "\n", "\n", "\n2"]
+# end
 
-def test_perform_word_wrap_trailing_new_line(_args, assert)
-  assert.equal! Input::Multiline.new.perform_word_wrap(['1', "\n"]).map(&:text), ['1', "\n"]
-end
+# def test_perform_word_wrap_trailing_new_line(_args, assert)
+#   assert.equal! Input::Multiline.new.perform_word_wrap(['1', "\n"]).map(&:text), ['1', "\n"]
+# end
 
-def test_find_word_breaks_trailing_new_line_after_wrap(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks("1234567890 1234567890 1234567890\n"), ['1234567890 ', '1234567890 ', '1234567890', "\n"]
-end
+# def test_find_word_breaks_trailing_new_line_after_wrap(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks("1234567890 1234567890 1234567890\n"), ['1234567890 ', '1234567890 ', '1234567890', "\n"]
+# end
 
-def test_perform_word_wrap_trailing_new_line_after_wrap(_args, assert)
-  assert.equal! Input::Multiline.new.perform_word_wrap(['1234567890 ', '1234567890 ', '1234567890', "\n"]).map(&:text), ['1234567890 1234567890 ', '1234567890', "\n"]
-end
+# def test_perform_word_wrap_trailing_new_line_after_wrap(_args, assert)
+#   assert.equal! Input::Multiline.new.perform_word_wrap(['1234567890 ', '1234567890 ', '1234567890', "\n"]).map(&:text), ['1234567890 1234567890 ', '1234567890', "\n"]
+# end
 
-def test_find_word_breaks_trailing_new_line_after_wrap_with_space(_args, assert)
-  assert.equal! Input::Multiline.new.find_word_breaks("1234567890 1234567890 \n"), ['1234567890 ', '1234567890 ', "\n"]
-end
+# def test_find_word_breaks_trailing_new_line_after_wrap_with_space(_args, assert)
+#   assert.equal! Input::Multiline.new.find_word_breaks("1234567890 1234567890 \n"), ['1234567890 ', '1234567890 ', "\n"]
+# end
 
 # def test_perform_word_wrap_trailing_new_line_after_wrap(args, assert)
 #   assert.equal! Input::Multiline.new.perform_word_wrap(['', '']), ["1\n", '']

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -86,6 +86,7 @@ def test_multiline_word_breaks_trailing_new_line(_args, assert)
   assert.equal! multiline.lines.map(&:text), ['hello, ', "\n"]
 end
 
+# REVIEW: Are these still needed?
 # def test_perform_word_wrap_multiple_new_lines(_args, assert)
 #   assert.equal! Input::Multiline.new.perform_word_wrap(['1', "\n", "\n", "\n2"]).map(&:text), ['1', "\n", "\n", "\n2"]
 # end


### PR DESCRIPTION
I wanted to contribute something else at first - but I saw that most of the unit tests were not working, so I tried to fix them first.....

I replaced direct calls to `find_word_breaks` and `perform_word_wrap` (which do not exist anymore at their original places) with hopefully equivalent tests involving an actual `Multiline` instance

I also improved the `test` script so it doesn't open a DR window (which makes it a bit faster and possible to use in environments without an actual screen like a CI system)

There were several tests about which I didn't know what to do with them. My intuition tells me that I can probably delete them but I was not sure if there was some crucial bit of word wrapping logic still hidden in there which I didn't translate into the new test format

Btw: are those `run` `test` etc scripts normal shell scripts? I think you might not need the final `cd -` since usually shells restore there old working directory after executing a script