### PR TITLE
Introduce FontStyle object & fix size_enum bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v0.0.13 - 16 May 2024
 
-* Fixed a bug where the input woul break if `size_enum` is specified as a number
+* Fixed a bug where the input would break if `size_enum` is specified as a number
 * Refactored string size calculations by encapsulating them into a `FontStyle` object
 
 # v0.0.12 - 12 May 2024

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v0.0.13 - 16 May 2024
+
+* Fixed a bug where the input woul break if `size_enum` is specified as a number
+* Refactored string size calculations by encapsulating them into a `FontStyle` object
+
 # v0.0.12 - 12 May 2024
 
 * Fixes wrapping of words longer than the width of the multi-line input

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -33,7 +33,7 @@ module Input
       @y = params[:y] || 0
 
       @font = params[:font].to_s
-      @size_enum = SIZE_ENUM.fetch(params[:size_enum] || :normal, :size_enum)
+      @size_enum = SIZE_ENUM.fetch(params[:size_enum] || :normal, params[:size_enum])
 
       word_chars = (params[:word_chars] || ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '-'])
       _, @font_height = $gtk.calcstringbox(word_chars.join(''), @size_enum, @font)

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -36,7 +36,8 @@ module Input
       @size_enum = SIZE_ENUM.fetch(params[:size_enum] || :normal, params[:size_enum])
 
       word_chars = (params[:word_chars] || ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '-'])
-      _, @font_height = $gtk.calcstringbox(word_chars.join(''), @size_enum, @font)
+      @font_style = FontStyle.new(font: @font, size_enum: @size_enum, word_chars: word_chars)
+      @font_height = @font_style.font_height
       @word_chars = Hash[word_chars.map { [_1, true] }]
       @punctuation_chars = Hash[(params[:punctuation_chars] || %w[! % , . ; : ' " ` ) \] } * &]).map { [_1, true] }]
       @crlf_chars = { "\r" => true, "\n" => true }

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -32,11 +32,11 @@ module Input
       @x = params[:x] || 0
       @y = params[:y] || 0
 
-      @font = params[:font].to_s
-      @size_enum = SIZE_ENUM.fetch(params[:size_enum] || :normal, params[:size_enum])
+      font = params[:font].to_s
+      size_enum = SIZE_ENUM.fetch(params[:size_enum] || :normal, params[:size_enum])
 
       word_chars = (params[:word_chars] || ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '-'])
-      @font_style = FontStyle.new(font: @font, size_enum: @size_enum, word_chars: word_chars)
+      @font_style = FontStyle.new(font: font, size_enum: size_enum, word_chars: word_chars)
       @font_height = @font_style.font_height
       @word_chars = Hash[word_chars.map { [_1, true] }]
       @punctuation_chars = Hash[(params[:punctuation_chars] || %w[! % , . ; : ' " ` ) \] } * &]).map { [_1, true] }]

--- a/lib/font_style.rb
+++ b/lib/font_style.rb
@@ -6,4 +6,8 @@ class FontStyle
     @size_enum = size_enum
     _, @font_height = $gtk.calcstringbox(word_chars.join(''), @size_enum, @font)
   end
+
+  def string_width(str)
+    $gtk.calcstringbox(str, @size_enum, @font)[0]
+  end
 end

--- a/lib/font_style.rb
+++ b/lib/font_style.rb
@@ -1,0 +1,9 @@
+class FontStyle
+  attr_reader :font_height
+
+  def initialize(font:, size_enum:, word_chars:)
+    @font = font
+    @size_enum = size_enum
+    _, @font_height = $gtk.calcstringbox(word_chars.join(''), @size_enum, @font)
+  end
+end

--- a/lib/font_style.rb
+++ b/lib/font_style.rb
@@ -10,4 +10,8 @@ class FontStyle
   def string_width(str)
     $gtk.calcstringbox(str, @size_enum, @font)[0]
   end
+
+  def label(values)
+    { size_enum: @size_enum, font: @font, **values }
+  end
 end

--- a/lib/input.rb
+++ b/lib/input.rb
@@ -1,6 +1,7 @@
 # Initially based loosely on code from Zif (https://github.com/danhealy/dragonruby-zif)
 require_relative 'value.rb'
 require_relative 'line_collection.rb'
+require_relative 'font_style.rb'
 require_relative 'base.rb'
 require_relative 'text.rb'
 require_relative 'multiline.rb'

--- a/lib/line_collection.rb
+++ b/lib/line_collection.rb
@@ -66,14 +66,12 @@ module Input
   end
 
   class LineCollection
-    attr_reader :text_length, :lines
+    attr_reader :lines
 
     include Enumerable
 
-    def initialize(font, size_enum, lines = [])
+    def initialize(lines = [])
       @lines = lines
-      @font = font
-      @size_enum = size_enum
     end
 
     def each
@@ -131,7 +129,7 @@ module Input
         line = @lines[i += 1]
       end
 
-      LineCollection.new(@font, @size_enum, modified_lines)
+      LineCollection.new(modified_lines)
     end
 
     def text
@@ -213,7 +211,7 @@ module Input
 
     def perform_word_wrap(text, width, first_line_number = 0, first_line_start = 0)
       words = find_word_breaks(text)
-      lines = LineCollection.new(@font, @size_enum)
+      lines = LineCollection.new
       line = ''
       i = -1
       le = words.length

--- a/lib/line_collection.rb
+++ b/lib/line_collection.rb
@@ -3,7 +3,7 @@ module Input
     attr_reader :text, :clean_text, :start, :end, :length, :wrapped, :new_line
     attr_accessor :number
 
-    def initialize(number, start, text, wrapped, font, size_enum)
+    def initialize(number, start, text, wrapped, font_style)
       @number = number
       @start = start
       @text = text
@@ -12,8 +12,7 @@ module Input
       @end = start + @length
       @wrapped = wrapped
       @new_line = text[0] == "\n"
-      @font = font
-      @size_enum = size_enum
+      @font_style = font_style
     end
 
     def start=(val)
@@ -39,9 +38,9 @@ module Input
 
     def measure_to(index)
       if @text[0] == "\n"
-        index < 1 ? 0 : $gtk.calcstringbox(@text[1, index - 1].to_s, @size_enum, @font)[0]
+        index < 1 ? 0 : @font_style.string_width(@text[1, index - 1].to_s)
       else
-        $gtk.calcstringbox(@text[0, index].to_s, @size_enum, @font)[0]
+        @font_style.string_width(@text[0, index].to_s)
       end
     end
 
@@ -52,7 +51,7 @@ module Input
       width = 0
       while (index += 1) < length
         char = @text[index, 1]
-        char_w = char == "\n" ? 0 : $gtk.calcstringbox(char, @size_enum, @font)[0]
+        char_w = char == "\n" ? 0 : @font_style.string_width(char)
         # TODO: Test `index_at` with multiple different fonts
         char_mid = char_w / 4
         return index + @start if width + char_mid > x
@@ -146,11 +145,10 @@ module Input
   end
 
   class LineParser
-    def initialize(word_wrap_chars, crlf_chars, font, size_enum)
+    def initialize(word_wrap_chars, crlf_chars, font_style:)
       @word_wrap_chars = word_wrap_chars
       @crlf_chars = crlf_chars
-      @font = font
-      @size_enum = size_enum
+      @font_style = font_style
     end
 
     def find_word_breaks(text)
@@ -219,36 +217,36 @@ module Input
         word = words[i]
         if word == "\n"
           unless line == ''
-            lines << Line.new(lines.length + first_line_number, first_line_start, line, false, @font, @size_enum)
+            lines << Line.new(lines.length + first_line_number, first_line_start, line, false, @font_style)
             first_line_start = lines.last.end
           end
           line = word
         else
-          w, = $gtk.calcstringbox((line + word).rstrip, @size_enum, @font)
+          w = @font_style.string_width((line + word).rstrip)
           if w > width
             unless line == ''
-              lines << Line.new(lines.length + first_line_number, first_line_start, line, true, @font, @size_enum)
+              lines << Line.new(lines.length + first_line_number, first_line_start, line, true, @font_style)
               first_line_start = lines.last.end
             end
 
             # break up long words
-            w, = $gtk.calcstringbox(word.rstrip, @size_enum, @font)
+            w = @font_style.string_width(word.rstrip)
             # TODO: make this a binary search
             while w > width
               r = word.length - 1
               l = 0
               m = r.idiv(2)
-              w, = $gtk.calcstringbox(word[0, m].rstrip, @size_enum, @font)
+              w = @font_style.string_width(word[0, m].rstrip)
               loop do
                 if w == width
                   # Whoa, add this
-                  lines << Line.new(lines.length + first_line_number, first_line_start, word[0, m], true, @font, @size_enum)
+                  lines << Line.new(lines.length + first_line_number, first_line_start, word[0, m], true, @font_style)
                   first_line_start = lines.last.end
                   word = word[m, word.length]
                   break
                 elsif w < width
                   if r - l <= 1
-                    lines << Line.new(lines.length + first_line_number, first_line_start, word[0, r], true, @font, @size_enum)
+                    lines << Line.new(lines.length + first_line_number, first_line_start, word[0, r], true, @font_style)
                     first_line_start = lines.last.end
                     word = word[r, word.length]
                     break
@@ -259,7 +257,7 @@ module Input
                   m = (l + r).idiv(2)
                 elsif w > width
                   if r - l <= 1
-                    lines << Line.new(lines.length + first_line_number, first_line_start, word[0, l], true, @font, @size_enum)
+                    lines << Line.new(lines.length + first_line_number, first_line_start, word[0, l], true, @font_style)
                     first_line_start = lines.last.end
                     word = word[l, word.length]
                     break
@@ -269,14 +267,14 @@ module Input
                   r = m - 1
                   m = (l + r).idiv(2)
                 end
-                w, = $gtk.calcstringbox(word[0, m].rstrip, @size_enum, @font)
+                w = @font_style.string_width(word[0, m].rstrip)
               end
-              w, = $gtk.calcstringbox(word.rstrip, @size_enum, @font)
+              w = @font_style.string_width(word.rstrip)
             end
             line = word
           elsif word.start_with?("\n")
             unless line == ''
-              lines << Line.new(lines.length + first_line_number, first_line_start, line, false, @font, @size_enum)
+              lines << Line.new(lines.length + first_line_number, first_line_start, line, false, @font_style)
               first_line_start = lines.last.end
             end
             line = word
@@ -286,7 +284,7 @@ module Input
         end
       end
 
-      lines << Line.new(lines.length + first_line_number, first_line_start, line, false, @font, @size_enum)
+      lines << Line.new(lines.length + first_line_number, first_line_start, line, false, @font_style)
     end
   end
 end

--- a/lib/multiline.rb
+++ b/lib/multiline.rb
@@ -6,7 +6,7 @@ module Input
       super
 
       word_wrap_chars = @word_chars.merge(@punctuation_chars)
-      @value = MultilineValue.new(value, word_wrap_chars, @crlf_chars, @font, @size_enum, @w)
+      @value = MultilineValue.new(value, word_wrap_chars, @crlf_chars, @w, font_style: @font_style)
       @fill_from_bottom = params[:fill_from_bottom] || false
     end
 

--- a/lib/multiline.rb
+++ b/lib/multiline.rb
@@ -329,10 +329,10 @@ module Input
         @scroll_x = 0
         if @fill_from_bottom
           @cursor_y = 0
-          rt.primitives << { x: 0, y: 0, text: @prompt, size_enum: @size_enum, font: @font }.label!(@prompt_color)
+          rt.primitives << @font_style.label(x: 0, y: 0, text: @prompt, **@prompt_color)
         else
           @cursor_y = @h - @font_height
-          rt.primitives << { x: 0, y: @h - @font_height, text: @prompt, size_enum: @size_enum, font: @font }.label!(@prompt_color)
+          rt.primitives << @font_style.label(x: 0, y: @h - @font_height, text: @prompt, **@prompt_color)
         end
       else
         # CURSOR AND SCROLL LOCATION
@@ -389,7 +389,7 @@ module Input
           end
 
           # TEXT FOR LINE
-          rt.primitives << { x: 0, y: y, text: line.clean_text, size_enum: @size_enum, font: @font }.label!(@text_color)
+          rt.primitives << @font_style.label(x: 0, y: y, text: line.clean_text, **@text_color)
         end
       end
 

--- a/lib/text.rb
+++ b/lib/text.rb
@@ -134,7 +134,7 @@ module Input
         return l if l > r
 
         m = ((l + r) / 2).floor
-        px = $gtk.calcstringbox(str[0, m].to_s, @size_enum, @font)[0]
+        px = @font_style.string_width(str[0, m].to_s)
         if px == x
           return m
         elsif px < x
@@ -155,7 +155,7 @@ module Input
         sc = @blurred_selection_color
       end
 
-      @scroll_w = $gtk.calcstringbox(@value.to_s, @size_enum, @font)[0].ceil
+      @scroll_w = @font_style.string_width(@value.to_s).ceil
       @content_w = @w.lesser(@scroll_w)
       @scroll_h = @content_h = @h
 
@@ -173,7 +173,7 @@ module Input
         rt.primitives << { x: 0, y: @padding, text: @prompt, size_enum: @size_enum, font: @font }.label!(@prompt_color)
       else
         # CURSOR AND SCROLL LOCATION
-        @cursor_x = $gtk.calcstringbox(@value[0, @selection_end].to_s, @size_enum, @font)[0]
+        @cursor_x = @font_style.string_width(@value[0, @selection_end].to_s)
         @cursor_y = 0
 
         if @content_w < @w
@@ -191,11 +191,11 @@ module Input
         # SELECTION
         if @selection_start != @selection_end
           if @selection_start < @selection_end
-            left = ($gtk.calcstringbox(@value[0, @selection_start].to_s, @size_enum, @font)[0] - @scroll_x).cap_min_max(0, @w)
-            right = ($gtk.calcstringbox(@value[0, @selection_end].to_s, @size_enum, @font)[0] - @scroll_x).cap_min_max(0, @w)
+            left = (@font_style.string_width(@value[0, @selection_start].to_s) - @scroll_x).cap_min_max(0, @w)
+            right = (@font_style.string_width(@value[0, @selection_end].to_s) - @scroll_x).cap_min_max(0, @w)
           elsif @selection_start > @selection_end
-            left = ($gtk.calcstringbox(@value[0, @selection_end].to_s, @size_enum, @font)[0] - @scroll_x).cap_min_max(0, @w)
-            right = ($gtk.calcstringbox(@value[0, @selection_start].to_s, @size_enum, @font)[0] - @scroll_x).cap_min_max(0, @w)
+            left = (@font_style.string_width(@value[0, @selection_end].to_s) - @scroll_x).cap_min_max(0, @w)
+            right = (@font_style.string_width(@value[0, @selection_start].to_s) - @scroll_x).cap_min_max(0, @w)
           end
 
           rt.primitives << { x: left, y: @padding, w: right - left, h: @font_height + @padding * 2 }.solid!(sc)

--- a/lib/text.rb
+++ b/lib/text.rb
@@ -170,7 +170,7 @@ module Input
         @cursor_x = 0
         @cursor_y = 0
         @scroll_x = 0
-        rt.primitives << { x: 0, y: @padding, text: @prompt, size_enum: @size_enum, font: @font }.label!(@prompt_color)
+        rt.primitives << @font_style.label(x: 0, y: @padding, text: @prompt, **@prompt_color)
       else
         # CURSOR AND SCROLL LOCATION
         @cursor_x = @font_style.string_width(@value[0, @selection_end].to_s)
@@ -204,7 +204,7 @@ module Input
         # TEXT
         f = find_index_at_x(@scroll_x)
         l = find_index_at_x(@scroll_x + @content_w) + 2
-        rt.primitives << { x: 0, y: @padding, text: @value[f, l - f], size_enum: @size_enum, font: @font }.label!(@text_color)
+        rt.primitives << @font_style.label(x: 0, y: @padding, text: @value[f, l - f], **@text_color)
       end
 
       draw_cursor(rt)

--- a/lib/value.rb
+++ b/lib/value.rb
@@ -43,9 +43,9 @@ module Input
   class MultilineValue
     attr_reader :lines
 
-    def initialize(text, word_wrap_chars, crlf_chars, font, size_enum, w)
+    def initialize(text, word_wrap_chars, crlf_chars, w, font_style:)
       @w = w
-      @line_parser = LineParser.new(word_wrap_chars, crlf_chars, font, size_enum)
+      @line_parser = LineParser.new(word_wrap_chars, crlf_chars, font_style: font_style)
       @lines = @line_parser.perform_word_wrap(text, @w)
     end
 

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -145,6 +145,40 @@ def test_text_drag_inside_sets_selection(args, assert)
   assert.equal! input.selection_end, 6
 end
 
+def test_multiline_click_inside_sets_selection(args, assert)
+  $args = args
+  three_letters_wide, font_height = $gtk.calcstringbox('ABC', 0)
+  input = Input::Multiline.new(x: 100, y: 100, w: 100, h: font_height * 2, size_enum: 0, value: "ABCDEF\nGHIJKL", focussed: true)
+
+  mouse_is_at(100 + three_letters_wide, 105)
+  mouse_down
+  input.tick
+  mouse_up
+  input.tick
+
+
+  # 10 = ABCDEF\nGHI
+  assert.equal! input.selection_start, 10
+  assert.equal! input.selection_end, 10
+end
+
+def test_text_drag_inside_sets_selection(args, assert)
+  $args = args
+  three_letters_wide, font_height = $gtk.calcstringbox('ABC', 0)
+  input = Input::Multiline.new(x: 100, y: 100, w: 100, h: font_height * 2, size_enum: 0, value: "ABCDEF\nGHIJKL", focussed: true)
+
+  mouse_is_at(100 + three_letters_wide, 105 + font_height)
+  mouse_down
+  input.tick
+
+  mouse_is_at(100 + three_letters_wide, 105)
+  mouse_up
+  input.tick
+
+  assert.equal! input.selection_start, 3
+  assert.equal! input.selection_end, 10
+end
+
 def build_multiline_input(width_in_letters)
   # This works because the default DR font is monospaced
   width, _ = $gtk.calcstringbox('1' * width_in_letters, 0)

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -90,7 +90,7 @@ end
 
 def test_default_height_is_calculated_from_padding_and_font_height(_args, assert)
   _, font_height = $gtk.calcstringbox('A', 0)
-  text_input = Input::Text.new(padding: 10)
+  text_input = Input::Text.new(padding: 10, size_enum: 0)
 
   assert.equal! text_input.h, font_height + 20
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -95,6 +95,23 @@ def test_default_height_is_calculated_from_padding_and_font_height(_args, assert
   assert.equal! text_input.h, font_height + 20
 end
 
+def test_multiline_scrolls_in_font_height_steps_by_default(args, assert)
+  $args = args
+  _, font_height = $gtk.calcstringbox('A', 0)
+  input = Input::Multiline.new(x: 100, y: 100, w: 100, size_enum: 0)
+  input.insert "line 1\n"
+  input.insert "line 2\n"
+  input.insert "line 3\n"
+
+  assert.equal! input.scroll_y, 0
+
+  mouse_is_inside(input)
+  args.inputs.mouse.wheel = { y: 1 }
+  input.tick
+
+  assert.equal! input.scroll_y, font_height
+end
+
 def build_multiline_input(width_in_letters)
   # This works because the default DR font is monospaced
   width, _ = $gtk.calcstringbox('1' * width_in_letters, 0)
@@ -105,4 +122,9 @@ def word_wrap_result(string, width_in_letters = 10)
   multiline = build_multiline_input(10)
   multiline.insert string
   multiline.lines.map(&:text)
+end
+
+def mouse_is_inside(rect)
+  $args.inputs.mouse.x = rect.x + rect.w.half
+  $args.inputs.mouse.y = rect.y + rect.h.half
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -118,10 +118,10 @@ def test_text_click_inside_sets_selection(args, assert)
   input = Input::Text.new(x: 100, y: 100, w: 100, size_enum: 0, value: 'ABCDEF', focussed: true)
 
   mouse_is_inside(input, x: 100 + three_letters_wide)
-  args.mouse.click = true
+  mouse_down
   input.tick
 
-  args.mouse.click = false
+  mouse_up
   input.tick
 
   assert.equal! input.selection_start, 3
@@ -135,11 +135,10 @@ def test_text_drag_inside_sets_selection(args, assert)
   input = Input::Text.new(x: 100, y: 100, w: 100, size_enum: 0, value: 'ABCDEFGH', focussed: true)
 
   mouse_is_inside(input, x: 100 + three_letters_wide)
-  args.mouse.click = true
+  mosue_down
   input.tick
-
   mouse_is_inside(input, x: 100 + six_letters_wide)
-  args.mouse.click = false
+  mouse_up
   input.tick
 
   assert.equal! input.selection_start, 3
@@ -168,4 +167,16 @@ def mouse_is_inside(rect, x: nil)
     x || rect.x + rect.w.half,
     rect.y + rect.h.half
   )
+end
+
+def mouse_down
+  $args.inputs.mouse.button_left = true
+  $args.inputs.mouse.click = GTK::MousePoint.new($args.inputs.mouse.x, $args.inputs.mouse.y)
+  $args.inputs.mouse.up = false
+end
+
+def mouse_up
+  $args.inputs.mouse.button_left = false
+  $args.inputs.mouse.click = nil
+  $args.inputs.mouse.up = true
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -114,10 +114,10 @@ end
 
 def test_text_click_inside_sets_selection(args, assert)
   $args = args
-  three_letters_width, _ = $gtk.calcstringbox('ABC', 0)
+  three_letters_wide, _ = $gtk.calcstringbox('ABC', 0)
   input = Input::Text.new(x: 100, y: 100, w: 100, size_enum: 0, value: 'ABCDEF', focussed: true)
 
-  mouse_is_at(100 + three_letters_width, 105)
+  mouse_is_inside(input, x: 100 + three_letters_wide)
   args.mouse.click = true
   input.tick
 
@@ -130,15 +130,15 @@ end
 
 def test_text_drag_inside_sets_selection(args, assert)
   $args = args
-  three_letters_width, _ = $gtk.calcstringbox('ABC', 0)
-  six_letters_width, _ = $gtk.calcstringbox('ABCDEF', 0)
+  three_letters_wide, _ = $gtk.calcstringbox('ABC', 0)
+  six_letters_wide, _ = $gtk.calcstringbox('ABCDEF', 0)
   input = Input::Text.new(x: 100, y: 100, w: 100, size_enum: 0, value: 'ABCDEFGH', focussed: true)
 
-  mouse_is_at(100 + three_letters_width, 105)
+  mouse_is_inside(input, x: 100 + three_letters_wide)
   args.mouse.click = true
   input.tick
 
-  mouse_is_at(100 + six_letters_width, 105)
+  mouse_is_inside(input, x: 100 + six_letters_wide)
   args.mouse.click = false
   input.tick
 
@@ -163,9 +163,9 @@ def mouse_is_at(x, y)
   $args.inputs.mouse.y = y
 end
 
-def mouse_is_inside(rect)
+def mouse_is_inside(rect, x: nil)
   mouse_is_at(
-    rect.x + rect.w.half,
+    x || rect.x + rect.w.half,
     rect.y + rect.h.half
   )
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -88,6 +88,13 @@ def test_multiline_word_breaks_breaks_very_long_word_after_something_that_isnt(_
   assert.equal! word_wrap_result('Super califragilisticexpialidocious'), ['Super ', 'califragil', 'isticexpia', 'lidocious']
 end
 
+def test_default_height_is_calculated_from_padding_and_font_height(_args, assert)
+  _, font_height = $gtk.calcstringbox('A', 0)
+  text_input = Input::Text.new(padding: 10)
+
+  assert.equal! text_input.h, font_height + 20
+end
+
 def build_multiline_input(width_in_letters)
   # This works because the default DR font is monospaced
   width, _ = $gtk.calcstringbox('1' * width_in_letters, 0)

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -112,6 +112,40 @@ def test_multiline_scrolls_in_font_height_steps_by_default(args, assert)
   assert.equal! input.scroll_y, font_height
 end
 
+def test_text_click_inside_sets_selection(args, assert)
+  $args = args
+  three_letters_width, _ = $gtk.calcstringbox('ABC', 0)
+  input = Input::Text.new(x: 100, y: 100, w: 100, size_enum: 0, value: 'ABCDEF', focussed: true)
+
+  mouse_is_at(100 + three_letters_width, 105)
+  args.mouse.click = true
+  input.tick
+
+  args.mouse.click = false
+  input.tick
+
+  assert.equal! input.selection_start, 3
+  assert.equal! input.selection_end, 3
+end
+
+def test_text_drag_inside_sets_selection(args, assert)
+  $args = args
+  three_letters_width, _ = $gtk.calcstringbox('ABC', 0)
+  six_letters_width, _ = $gtk.calcstringbox('ABCDEF', 0)
+  input = Input::Text.new(x: 100, y: 100, w: 100, size_enum: 0, value: 'ABCDEFGH', focussed: true)
+
+  mouse_is_at(100 + three_letters_width, 105)
+  args.mouse.click = true
+  input.tick
+
+  mouse_is_at(100 + six_letters_width, 105)
+  args.mouse.click = false
+  input.tick
+
+  assert.equal! input.selection_start, 3
+  assert.equal! input.selection_end, 6
+end
+
 def build_multiline_input(width_in_letters)
   # This works because the default DR font is monospaced
   width, _ = $gtk.calcstringbox('1' * width_in_letters, 0)
@@ -124,7 +158,14 @@ def word_wrap_result(string, width_in_letters = 10)
   multiline.lines.map(&:text)
 end
 
+def mouse_is_at(x, y)
+  $args.inputs.mouse.x = x
+  $args.inputs.mouse.y = y
+end
+
 def mouse_is_inside(rect)
-  $args.inputs.mouse.x = rect.x + rect.w.half
-  $args.inputs.mouse.y = rect.y + rect.h.half
+  mouse_is_at(
+    rect.x + rect.w.half,
+    rect.y + rect.h.half
+  )
 end

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -149,8 +149,9 @@ def test_multiline_click_inside_sets_selection(args, assert)
   $args = args
   three_letters_wide, font_height = $gtk.calcstringbox('ABC', 0)
   input = Input::Multiline.new(x: 100, y: 100, w: 100, h: font_height * 2, size_enum: 0, value: "ABCDEF\nGHIJKL", focussed: true)
+  inside_second_line_y = input.y + font_height.half
 
-  mouse_is_at(100 + three_letters_wide, 105)
+  mouse_is_at(100 + three_letters_wide, inside_second_line_y)
   mouse_down
   input.tick
   mouse_up
@@ -166,12 +167,14 @@ def test_text_drag_inside_sets_selection(args, assert)
   $args = args
   three_letters_wide, font_height = $gtk.calcstringbox('ABC', 0)
   input = Input::Multiline.new(x: 100, y: 100, w: 100, h: font_height * 2, size_enum: 0, value: "ABCDEF\nGHIJKL", focussed: true)
+  inside_second_line_y = input.y + font_height.half
+  inside_first_line_y = inside_second_line_y + font_height
 
-  mouse_is_at(100 + three_letters_wide, 105 + font_height)
+  mouse_is_at(100 + three_letters_wide, inside_first_line_y)
   mouse_down
   input.tick
 
-  mouse_is_at(100 + three_letters_wide, 105)
+  mouse_is_at(100 + three_letters_wide, inside_second_line_y)
   mouse_up
   input.tick
 


### PR DESCRIPTION
Extracted a `FontStyle` object to encapsulate string size calculations (in preparation for supporting `size_px`)

1. Wrote a few tests covering most of the features involving string size calculation (except rendering - so please check if it all still looks alright :D)
2. Use `@font` and `@size_enum` to construct a `FontStyle` object which can calculate string width & font_height
3. Use `@font_style.string_width` instead of `calcstringbox` everywhere and pass around `@font_style` instead of `@font` and `@size_enum`
4. Also added a `FontStyle#label` method as convenience to construct a label primitive hash with the correct values added

Also fixed a bug which prevented you from specifying `size_enum` as a number