### PR TITLE
Support size_px

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ The argument list below will list `prompt_color` but not the individual `prompt_
 * `padding` - padding, default 2
 * `font` - font path (eg. `'fonts/myfont.ttf'`), default ''
 * `size_enum` - size enumeration (integer), or named size such as `:small`, `:normal`, `:large`, default: `:normal` (`0`)
+* `size_px` - font size in pixels, takes precedence over `size_enum` if given
 * `text_color` - text color, default `{ r: 0, g: 0, b: 0, a: 255 }`
 * `r` - text color, red component, default 0, used if `text_color` is `nil`
 * `g` - text color, green component, default 0, used if `text_color` is `nil`

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -34,9 +34,14 @@ module Input
 
       font = params[:font].to_s
       size_enum = SIZE_ENUM.fetch(params[:size_enum] || :normal, params[:size_enum])
+      size_px = params[:size_px]
 
       word_chars = (params[:word_chars] || ('a'..'z').to_a + ('A'..'Z').to_a + ('0'..'9').to_a + ['_', '-'])
-      @font_style = FontStyle.new(font: font, size_enum: size_enum, word_chars: word_chars)
+      @font_style = if size_px
+                      FontStyle.new(font: font, size_px: size_px, word_chars: word_chars)
+                    else
+                      FontStyle.new(font: font, size_enum: size_enum, word_chars: word_chars)
+                    end
       @font_height = @font_style.font_height
       @word_chars = Hash[word_chars.map { [_1, true] }]
       @punctuation_chars = Hash[(params[:punctuation_chars] || %w[! % , . ; : ' " ` ) \] } * &]).map { [_1, true] }]

--- a/lib/font_style.rb
+++ b/lib/font_style.rb
@@ -3,15 +3,19 @@ class FontStyle
 
   def initialize(font:, size_enum:, word_chars:)
     @font = font
-    @size_enum = size_enum
-    _, @font_height = $gtk.calcstringbox(word_chars.join(''), @size_enum, @font)
+    @label_params = { size_enum: size_enum }
+    _, @font_height = $gtk.calcstringbox(word_chars.join(''), font: @font, **@label_params)
   end
 
   def string_width(str)
-    $gtk.calcstringbox(str, @size_enum, @font)[0]
+    $gtk.calcstringbox(str, font: @font, **@label_params)[0]
   end
 
   def label(values)
-    { size_enum: @size_enum, font: @font, **values }
+    {
+      font: @font,
+      **@label_params,
+      **values
+    }
   end
 end

--- a/lib/font_style.rb
+++ b/lib/font_style.rb
@@ -1,9 +1,9 @@
 class FontStyle
   attr_reader :font_height
 
-  def initialize(font:, size_enum:, word_chars:)
+  def initialize(font:,  word_chars:, size_enum: nil, size_px: nil)
     @font = font
-    @label_params = { size_enum: size_enum }
+    @label_params = size_px ? { size_px: size_px } : { size_enum: size_enum }
     _, @font_height = $gtk.calcstringbox(word_chars.join(''), font: @font, **@label_params)
   end
 

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -182,6 +182,32 @@ def test_text_drag_inside_sets_selection(args, assert)
   assert.equal! input.selection_end, 10
 end
 
+# Two representative test cases using size_px instead of size_enum
+
+def test_default_height_is_calculated_from_padding_and_font_height_size_px(_args, assert)
+  _, font_height = $gtk.calcstringbox('A', size_px: 30)
+  text_input = Input::Text.new(padding: 10, size_px: 30)
+
+  assert.equal! text_input.h, font_height + 20
+end
+
+def test_text_drag_inside_sets_selection_size_px(args, assert)
+  $args = args
+  three_letters_wide, _ = $gtk.calcstringbox('ABC', size_px: 44)
+  six_letters_wide, _ = $gtk.calcstringbox('ABCDEF', size_px: 44)
+  input = Input::Text.new(x: 100, y: 100, w: 200, size_px: 44, value: 'ABCDEFGH', focussed: true)
+
+  mouse_is_inside(input, x: 100 + three_letters_wide)
+  mouse_down
+  input.tick
+  mouse_is_inside(input, x: 100 + six_letters_wide)
+  mouse_up
+  input.tick
+
+  assert.equal! input.selection_start, 3
+  assert.equal! input.selection_end, 6
+end
+
 def build_multiline_input(width_in_letters)
   # This works because the default DR font is monospaced
   width, _ = $gtk.calcstringbox('1' * width_in_letters, 0)

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -28,6 +28,9 @@ def test_calcstringbox_tab_has_no_witdh(_args, assert)
   assert.equal! h, 22.0 # Yep, it has a height
 end
 
+
+# ---------------------- Line wrap tests ----------------------
+
 def test_find_word_breaks_empty_value(_args, assert)
   assert.equal! word_wrap_result(''), ['']
 end
@@ -87,6 +90,9 @@ end
 def test_multiline_word_breaks_breaks_very_long_word_after_something_that_isnt(_args, assert)
   assert.equal! word_wrap_result('Super califragilisticexpialidocious'), ['Super ', 'califragil', 'isticexpia', 'lidocious']
 end
+
+
+# ---------------------- Font size calculation tests ----------------------
 
 def test_default_height_is_calculated_from_padding_and_font_height(_args, assert)
   _, font_height = $gtk.calcstringbox('A', 0)
@@ -207,6 +213,9 @@ def test_text_drag_inside_sets_selection_size_px(args, assert)
   assert.equal! input.selection_start, 3
   assert.equal! input.selection_end, 6
 end
+
+
+# ---------------------- helper methods ----------------------
 
 def build_multiline_input(width_in_letters)
   # This works because the default DR font is monospaced


### PR DESCRIPTION
Added size_px support - the only caveat is... that the current implementation using `$gtk.calcstringbox` keyword arguments means that the minimum supported DR version now is 5.27... I'm also not sure about the performance implications of using a **splat instead of directly writing the arguments

Alternatively I have another version in #16 which is a bit more involved