### PR TITLE
delete_back for empty value does not move selection.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v0.0.24 - 9 March 2025
+
+* Fixed a bug that caused `delete_back` to result in negative `selection_start`/`selection_end` for an empty input. (thanks @Artem on Discord for reporting and sending the PR)
+
 # v0.0.23 - 17 February 2025
 
 * Exposed `@text_keys` as an instance variable instead of a local.

--- a/lib/base.rb
+++ b/lib/base.rb
@@ -360,7 +360,7 @@ module Input
     end
 
     def delete_back
-      @selection_start -= 1 if @selection_start == @selection_end
+      @selection_start -= 1 if @selection_start == @selection_end && @selection_start > 0
       insert('')
     end
 

--- a/metadata/game_metadata.txt
+++ b/metadata/game_metadata.txt
@@ -3,7 +3,7 @@ devid=fascinationworks
 devtitle=Fascination Works
 gameid=dr-input
 gametitle=Dragon Ruby Input
-version=0.0.23
+version=0.0.24
 icon=metadata/icon.png
 
 # === Flags available at all licensing tiers ===

--- a/tests/tests.rb
+++ b/tests/tests.rb
@@ -515,3 +515,23 @@ def mouse_up
   $args.inputs.mouse.click = nil
   $args.inputs.mouse.up = true
 end
+
+# ---------------------- delete_back ----------------------
+
+def test_delete_back(_args, assert)
+  input = build_text_input('1234567890', 10, 10)
+  input.delete_back
+
+  assert.equal! input.value.to_s, '123456789'
+  assert.equal! input.selection_end, 9
+  assert.equal! input.selection_start, 9
+end
+
+def test_delete_back_empty_value(_args, assert)
+  input = build_text_input('', 0, 0)
+  input.delete_back
+
+  assert.equal! input.value.to_s, ''
+  assert.equal! input.selection_end, 0
+  assert.equal! input.selection_start, 0
+end


### PR DESCRIPTION
Handling the issue when chars order getting mess if user tries to back delete something from the empty input.